### PR TITLE
Ensure HTTP responses close connections

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -402,7 +402,9 @@ async fn proxy(
         let (closed_tx, closed) = tokio::sync::oneshot::channel();
 
         // Send the request with Connection: close header
-        let resp = sender.send_request(req).await?;
+        let mut resp = sender.send_request(req).await?;
+        resp.headers_mut()
+            .insert("Connection", HeaderValue::from_static("close"));
 
         // Drop the sender to allow the closed future to resolve
         drop(sender);


### PR DESCRIPTION
## Summary
- Insert `Connection: close` header on responses so clients end connections immediately

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68937aa244c8832ab5ddd662b81d630a