### PR TITLE
Handle timed out HTTP connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ http = "0.2.9"
 hyper = { version = "1.0.0-rc.4", features = ["client","server","http1"] }
 clap = { version = "4", features = ["derive"] }
 tokio-socks = "0.5"
-tokio = { version = "1.28", features = ["macros", "rt-multi-thread", "signal", "process"] }
+tokio = { version = "1.28", features = ["macros", "rt-multi-thread", "signal", "process", "io-util"] }
 bytes = "1.4.0"
 http-body-util = "0.1.0-rc.2"
 tracing = "0.1.37"


### PR DESCRIPTION
## Summary
- gracefully close timed-out HTTP connections by sending a FIN and logging remaining SOCKS5 tunnels
- enable Tokio's io-util helpers for connection shutdowns

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68937bc95304832aa135f60220a222c5
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a timeout for HTTP connections and ensured they close cleanly by sending a FIN signal and logging remaining SOCKS5 tunnels.

- **Bug Fixes**
  - Closes timed-out HTTP connections to prevent resource leaks.
  - Logs active SOCKS5 tunnels after each connection ends.
  - Uses Tokio's io-util helpers for proper connection shutdown.

<!-- End of auto-generated description by cubic. -->

