### PR TITLE
Add configurable idle timeout for SOCKS5 tunnels

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Options:
       --no-httpauth <1/0>                  Ignore HTTP Basic Auth, [default: 1]
   -s, --socks-address <SOCKS_ADDRESS>      Socks5 proxy address [default: 127.0.0.1:1080]
       --allowed-domains <ALLOWED_DOMAINS>  Comma-separated list of allowed domains
+      --idle-timeout <IDLE_TIMEOUT>        Idle timeout in seconds for tunnel connections [default: 540]
   -h, --help                               Print help information
   -V, --version                            Print version information
 ```


### PR DESCRIPTION
## Summary
- allow `--idle-timeout` CLI option to configure tunnel idle period
- replace fixed tunnel timeout with idle-reset loop
- document new option in README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68943f182200832a85c767cdb4067bbd
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new --idle-timeout option to set how long SOCKS5 tunnels stay open when idle, replacing the fixed timeout with a configurable idle-reset loop.

- **New Features**
  - Added --idle-timeout CLI flag (default 540 seconds) to control tunnel idle timeout.
  - Updated tunnel logic to close connections after the set idle period.
  - Documented the new option in the README.

<!-- End of auto-generated description by cubic. -->

