### PR TITLE
Switch global trackers to async Tokio locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,12 +81,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,26 +188,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,12 +278,6 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -424,7 +392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -455,16 +423,6 @@ name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
-
-[[package]]
-name = "lock_api"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -545,19 +503,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
-name = "parking_lot_core"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,15 +550,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -667,12 +603,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,8 +650,6 @@ dependencies = [
  "bytes",
  "clap",
  "color-eyre",
- "crossbeam-utils",
- "dashmap",
  "http",
  "http-body-util",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ http = "1.1"
 hyper = { version = "1.5", features = ["client","server","http1"] }
 clap = { version = "4", features = ["derive"] }
 tokio-socks = "0.5"
-tokio = { version = "1.42", features = ["macros", "rt-multi-thread", "signal", "process", "io-util", "net"] }
+tokio = { version = "1.42", features = ["macros", "rt-multi-thread", "signal", "process", "io-util", "net", "sync"] }
 bytes = "1.8"
 http-body-util = "0.1"
 tracing = "0.1"
@@ -25,5 +25,3 @@ hyper-util = { version = "0.1", features = ["tokio", "client-legacy", "server-au
 base64 = "0.22"
 thiserror = "1.0"
 pin-project = "1.1"
-dashmap = "6.1.0"
-crossbeam-utils = "0.8.21"

--- a/src/buffer_pool.rs
+++ b/src/buffer_pool.rs
@@ -1,187 +1,98 @@
-use crossbeam_utils::CachePadded;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::Mutex;
 
 const MAX_POOL_SIZE: usize = 100;
 
-/// Lock-free buffer pool using a simple stack-based approach
-struct LockFreeBufferStack {
-    buffers: Vec<CachePadded<AtomicUsize>>, // Store buffer pointers as usize
-    top: AtomicUsize,
-}
-
-impl LockFreeBufferStack {
-    fn new() -> Self {
-        let mut buffers = Vec::with_capacity(MAX_POOL_SIZE);
-        for _ in 0..MAX_POOL_SIZE {
-            buffers.push(CachePadded::new(AtomicUsize::new(0)));
-        }
-        Self {
-            buffers,
-            top: AtomicUsize::new(0),
-        }
-    }
-
-    fn push(&self, buffer: Vec<u8>) -> bool {
-        let current_top = self.top.load(Ordering::Relaxed);
-        if current_top >= MAX_POOL_SIZE {
-            return false; // Pool is full
-        }
-
-        // Try to increment top
-        match self.top.compare_exchange(
-            current_top,
-            current_top + 1,
-            Ordering::AcqRel,
-            Ordering::Relaxed,
-        ) {
-            Ok(_) => {
-                // Successfully claimed a slot, store the buffer
-                let ptr = Box::into_raw(Box::new(buffer)) as usize;
-                self.buffers[current_top].store(ptr, Ordering::Release);
-                true
-            }
-            Err(_) => false, // Another thread beat us, drop the buffer
-        }
-    }
-
-    fn pop(&self) -> Option<Vec<u8>> {
-        loop {
-            let current_top = self.top.load(Ordering::Relaxed);
-            if current_top == 0 {
-                return None; // Pool is empty
-            }
-
-            // Try to decrement top
-            match self.top.compare_exchange(
-                current_top,
-                current_top - 1,
-                Ordering::AcqRel,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => {
-                    // Successfully claimed a buffer slot
-                    let ptr = self.buffers[current_top - 1].swap(0, Ordering::Acquire);
-                    if ptr != 0 {
-                        let buffer = unsafe { *Box::from_raw(ptr as *mut Vec<u8>) };
-                        return Some(buffer);
-                    }
-                    // Pointer was null (shouldn't happen in normal operation)
-                    // This indicates a bug, but we return None to avoid infinite loop
-                    return None;
-                }
-                Err(_) => continue, // Another thread beat us, try again
-            }
-        }
-    }
-
-    fn len(&self) -> usize {
-        self.top.load(Ordering::Relaxed)
-    }
-
-    fn clear(&self) {
-        while self.pop().is_some() {}
-    }
-}
-
-impl Drop for LockFreeBufferStack {
-    fn drop(&mut self) {
-        // Clean up any remaining buffers
-        self.clear();
-    }
-}
-
-/// Buffer pool for memory optimization
+/// Buffer pool for memory optimization backed by async-aware mutexes
 pub struct BufferPool {
-    small_buffers: LockFreeBufferStack, // 8KB buffers
-    large_buffers: LockFreeBufferStack, // 16KB buffers
+    small_buffers: Mutex<Vec<Vec<u8>>>, // 8KB buffers
+    large_buffers: Mutex<Vec<Vec<u8>>>, // 16KB buffers
 }
 
 impl BufferPool {
     /// Create a new buffer pool
     pub fn new() -> Self {
         Self {
-            small_buffers: LockFreeBufferStack::new(),
-            large_buffers: LockFreeBufferStack::new(),
+            small_buffers: Mutex::new(Vec::with_capacity(MAX_POOL_SIZE)),
+            large_buffers: Mutex::new(Vec::with_capacity(MAX_POOL_SIZE)),
+        }
+    }
+
+    /// Helper to determine buffer size based on `large` flag
+    fn buffer_size(large: bool) -> usize {
+        if large {
+            16_384
+        } else {
+            8_192
         }
     }
 
     /// Get a buffer from the pool or create a new one
-    ///
-    /// # Arguments
-    /// * `large` - If true, returns a 16KB buffer; otherwise returns an 8KB buffer
-    pub fn get_buffer(&self, large: bool) -> Vec<u8> {
-        let size = if large { 16384 } else { 8192 };
-        let pool = if large {
-            &self.large_buffers
+    pub async fn get_buffer(&self, large: bool) -> Vec<u8> {
+        let size = Self::buffer_size(large);
+        let mut pool = if large {
+            self.large_buffers.lock().await
         } else {
-            &self.small_buffers
+            self.small_buffers.lock().await
         };
 
         if let Some(mut buffer) = pool.pop() {
-            // Buffer was zeroed on return, capacity is preserved
-            // Just restore the length without zeroing again (optimization)
+            // Restore length without zeroing again; buffer was zeroed on return
             unsafe {
-                // SAFETY: The buffer was zeroed when returned to the pool,
-                // so all bytes up to capacity are initialized to 0.
-                // We're just restoring the length to the expected size.
                 buffer.set_len(size);
             }
-            return buffer;
+            buffer
+        } else {
+            vec![0u8; size]
         }
-
-        // Create new buffer if pool is empty
-        vec![0u8; size]
     }
 
     /// Return a buffer to the pool for reuse
-    ///
-    /// # Arguments
-    /// * `buffer` - The buffer to return to the pool
-    /// * `large` - Whether this is a large buffer (16KB) or small buffer (8KB)
-    pub fn return_buffer(&self, mut buffer: Vec<u8>, large: bool) {
-        // Only return buffers that are the expected size and capacity to avoid memory bloat
-        let expected_size = if large { 16384 } else { 8192 };
+    pub async fn return_buffer(&self, mut buffer: Vec<u8>, large: bool) {
+        let expected_size = Self::buffer_size(large);
 
-        // Reject buffers with wrong capacity
+        // Reject buffers with wrong capacity to avoid memory bloat
         if buffer.capacity() < expected_size || buffer.capacity() > expected_size * 2 {
             return;
         }
 
-        // Zero the buffer ONCE on return to avoid leaking data between connections
-        // This is the only place where we zero the buffer (optimization)
+        // Zero the buffer on return to avoid leaking data between connections
         buffer.clear();
         buffer.resize(expected_size, 0);
-        // After resize, buffer.len() == expected_size and all bytes are 0
-        // On next checkout, we'll just use set_len() without zeroing again
 
-        let pool = if large {
-            &self.large_buffers
+        let mut pool = if large {
+            self.large_buffers.lock().await
         } else {
-            &self.small_buffers
+            self.small_buffers.lock().await
         };
 
-        // Try to return to pool, drop if pool is full
-        let _ = pool.push(buffer);
+        if pool.len() < MAX_POOL_SIZE {
+            pool.push(buffer);
+        }
     }
 
     /// Get statistics about the buffer pool
-    #[allow(dead_code)]
-    pub fn stats(&self) -> BufferPoolStats {
-        let small_count = self.small_buffers.len();
-        let large_count = self.large_buffers.len();
+    pub async fn stats(&self) -> BufferPoolStats {
+        let small_count = {
+            let pool = self.small_buffers.lock().await;
+            pool.len()
+        };
+        let large_count = {
+            let pool = self.large_buffers.lock().await;
+            pool.len()
+        };
 
         BufferPoolStats {
             small_buffers_available: small_count,
             large_buffers_available: large_count,
-            total_memory_pooled: (small_count * 8192) + (large_count * 16384),
+            total_memory_pooled: (small_count * 8_192) + (large_count * 16_384),
         }
     }
 
     /// Clear all buffers from the pool (useful for testing or memory cleanup)
     #[allow(dead_code)]
-    pub fn clear(&self) {
-        self.small_buffers.clear();
-        self.large_buffers.clear();
+    pub async fn clear(&self) {
+        self.small_buffers.lock().await.clear();
+        self.large_buffers.lock().await.clear();
     }
 }
 
@@ -209,137 +120,137 @@ pub fn get_buffer_pool() -> &'static BufferPool {
 }
 
 /// Convenience function to get a buffer from the global pool
-pub fn get_buffer(large: bool) -> Vec<u8> {
-    get_buffer_pool().get_buffer(large)
+pub async fn get_buffer(large: bool) -> Vec<u8> {
+    get_buffer_pool().get_buffer(large).await
 }
 
 /// Convenience function to return a buffer to the global pool
-pub fn return_buffer(buffer: Vec<u8>, large: bool) {
-    get_buffer_pool().return_buffer(buffer, large);
+pub async fn return_buffer(buffer: Vec<u8>, large: bool) {
+    get_buffer_pool().return_buffer(buffer, large).await;
 }
 
 /// Get statistics from the global buffer pool
 #[allow(dead_code)]
-pub fn get_pool_stats() -> BufferPoolStats {
-    get_buffer_pool().stats()
+pub async fn get_pool_stats() -> BufferPoolStats {
+    get_buffer_pool().stats().await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_buffer_pool_basic_operations() {
+    #[tokio::test]
+    async fn test_buffer_pool_basic_operations() {
         let pool = BufferPool::new();
 
         // Test small buffer
-        let small_buf = pool.get_buffer(false);
-        assert_eq!(small_buf.len(), 8192);
+        let small_buf = pool.get_buffer(false).await;
+        assert_eq!(small_buf.len(), 8_192);
 
         // Test large buffer
-        let large_buf = pool.get_buffer(true);
-        assert_eq!(large_buf.len(), 16384);
+        let large_buf = pool.get_buffer(true).await;
+        assert_eq!(large_buf.len(), 16_384);
 
         // Return buffers
-        pool.return_buffer(small_buf, false);
-        pool.return_buffer(large_buf, true);
+        pool.return_buffer(small_buf, false).await;
+        pool.return_buffer(large_buf, true).await;
 
         // Get buffers again - should reuse from pool
-        let reused_small = pool.get_buffer(false);
-        let reused_large = pool.get_buffer(true);
+        let reused_small = pool.get_buffer(false).await;
+        let reused_large = pool.get_buffer(true).await;
 
-        assert_eq!(reused_small.len(), 8192);
-        assert_eq!(reused_large.len(), 16384);
+        assert_eq!(reused_small.len(), 8_192);
+        assert_eq!(reused_large.len(), 16_384);
     }
 
-    #[test]
-    fn test_buffer_pool_size_limit() {
+    #[tokio::test]
+    async fn test_buffer_pool_size_limit() {
         let pool = BufferPool::new();
 
         // Fill pool beyond limit
         for _ in 0..150 {
-            let buf = pool.get_buffer(false);
-            pool.return_buffer(buf, false);
+            let buf = pool.get_buffer(false).await;
+            pool.return_buffer(buf, false).await;
         }
 
         // Pool should limit size to prevent memory bloat
-        let stats = pool.stats();
+        let stats = pool.stats().await;
         assert!(stats.small_buffers_available <= 100);
     }
 
-    #[test]
-    fn test_buffer_pool_wrong_size_rejection() {
+    #[tokio::test]
+    async fn test_buffer_pool_wrong_size_rejection() {
         let pool = BufferPool::new();
 
         // Create a buffer with wrong size
-        let wrong_size_buffer = vec![0u8; 4096]; // 4KB instead of 8KB
-        
+        let wrong_size_buffer = vec![0u8; 4_096]; // 4KB instead of 8KB
+
         // Pool should reject it
-        pool.return_buffer(wrong_size_buffer, false);
-        
-        let stats = pool.stats();
+        pool.return_buffer(wrong_size_buffer, false).await;
+
+        let stats = pool.stats().await;
         assert_eq!(stats.small_buffers_available, 0);
     }
 
-    #[test]
-    fn test_buffer_pool_stats() {
+    #[tokio::test]
+    async fn test_buffer_pool_stats() {
         let pool = BufferPool::new();
-        
-        let initial_stats = pool.stats();
+
+        let initial_stats = pool.stats().await;
         assert_eq!(initial_stats.small_buffers_available, 0);
         assert_eq!(initial_stats.large_buffers_available, 0);
         assert_eq!(initial_stats.total_memory_pooled, 0);
 
         // Add some buffers
-        let small_buf = pool.get_buffer(false);
-        let large_buf = pool.get_buffer(true);
-        
-        pool.return_buffer(small_buf, false);
-        pool.return_buffer(large_buf, true);
+        let small_buf = pool.get_buffer(false).await;
+        let large_buf = pool.get_buffer(true).await;
 
-        let stats = pool.stats();
+        pool.return_buffer(small_buf, false).await;
+        pool.return_buffer(large_buf, true).await;
+
+        let stats = pool.stats().await;
         assert_eq!(stats.small_buffers_available, 1);
         assert_eq!(stats.large_buffers_available, 1);
-        assert_eq!(stats.total_memory_pooled, 8192 + 16384);
+        assert_eq!(stats.total_memory_pooled, 8_192 + 16_384);
     }
 
-    #[test]
-    fn test_buffer_pool_clear() {
+    #[tokio::test]
+    async fn test_buffer_pool_clear() {
         let pool = BufferPool::new();
-        
-        // Add some buffers
-        let small_buf = pool.get_buffer(false);
-        let large_buf = pool.get_buffer(true);
-        
-        pool.return_buffer(small_buf, false);
-        pool.return_buffer(large_buf, true);
 
-        let stats_before = pool.stats();
+        // Add some buffers
+        let small_buf = pool.get_buffer(false).await;
+        let large_buf = pool.get_buffer(true).await;
+
+        pool.return_buffer(small_buf, false).await;
+        pool.return_buffer(large_buf, true).await;
+
+        let stats_before = pool.stats().await;
         assert!(stats_before.small_buffers_available > 0);
         assert!(stats_before.large_buffers_available > 0);
 
         // Clear the pool
-        pool.clear();
+        pool.clear().await;
 
-        let stats_after = pool.stats();
+        let stats_after = pool.stats().await;
         assert_eq!(stats_after.small_buffers_available, 0);
         assert_eq!(stats_after.large_buffers_available, 0);
         assert_eq!(stats_after.total_memory_pooled, 0);
     }
 
-    #[test]
-    fn test_global_buffer_pool_functions() {
+    #[tokio::test]
+    async fn test_global_buffer_pool_functions() {
         // Test global convenience functions
-        let small_buf = get_buffer(false);
-        assert_eq!(small_buf.len(), 8192);
+        let small_buf = get_buffer(false).await;
+        assert_eq!(small_buf.len(), 8_192);
 
-        let large_buf = get_buffer(true);
-        assert_eq!(large_buf.len(), 16384);
+        let large_buf = get_buffer(true).await;
+        assert_eq!(large_buf.len(), 16_384);
 
-        return_buffer(small_buf, false);
-        return_buffer(large_buf, true);
+        return_buffer(small_buf, false).await;
+        return_buffer(large_buf, true).await;
 
-        let stats = get_pool_stats();
+        let stats = get_pool_stats().await;
         assert!(stats.small_buffers_available > 0 || stats.large_buffers_available > 0);
     }
 }

--- a/src/traffic.rs
+++ b/src/traffic.rs
@@ -1,9 +1,10 @@
-use dashmap::DashMap;
+use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use tokio::sync::RwLock;
 
 /// Per-listener traffic counters (bytes)
 #[derive(Debug, Default)]
@@ -13,64 +14,80 @@ pub struct TrafficCounters {
 }
 
 impl TrafficCounters {
-    pub fn add_rx(&self, n: u64) { self.rx_bytes.fetch_add(n, Ordering::Relaxed); }
-    pub fn add_tx(&self, n: u64) { self.tx_bytes.fetch_add(n, Ordering::Relaxed); }
-    pub fn rx(&self) -> u64 { self.rx_bytes.load(Ordering::Relaxed) }
-    pub fn tx(&self) -> u64 { self.tx_bytes.load(Ordering::Relaxed) }
-    pub fn get(&self) -> (u64, u64) { (self.rx(), self.tx()) }
+    pub fn add_rx(&self, n: u64) {
+        self.rx_bytes.fetch_add(n, Ordering::Relaxed);
+    }
+    pub fn add_tx(&self, n: u64) {
+        self.tx_bytes.fetch_add(n, Ordering::Relaxed);
+    }
+    pub fn rx(&self) -> u64 {
+        self.rx_bytes.load(Ordering::Relaxed)
+    }
+    pub fn tx(&self) -> u64 {
+        self.tx_bytes.load(Ordering::Relaxed)
+    }
+    pub fn get(&self) -> (u64, u64) {
+        (self.rx(), self.tx())
+    }
     pub fn set(&self, rx: u64, tx: u64) {
         self.rx_bytes.store(rx, Ordering::Relaxed);
         self.tx_bytes.store(tx, Ordering::Relaxed);
     }
-    pub fn reset(&self) { self.set(0, 0); }
+    pub fn reset(&self) {
+        self.set(0, 0);
+    }
 }
 
 /// Global registry of traffic counters keyed by listening port
-static TRAFFIC_REGISTRY: std::sync::OnceLock<DashMap<u16, Arc<TrafficCounters>>> = std::sync::OnceLock::new();
+static TRAFFIC_REGISTRY: std::sync::OnceLock<RwLock<HashMap<u16, Arc<TrafficCounters>>>> =
+    std::sync::OnceLock::new();
 
-fn registry() -> &'static DashMap<u16, Arc<TrafficCounters>> {
-    TRAFFIC_REGISTRY.get_or_init(|| DashMap::new())
+fn registry() -> &'static RwLock<HashMap<u16, Arc<TrafficCounters>>> {
+    TRAFFIC_REGISTRY.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
 /// Get or create counters for a given listening port
-pub fn get_counters_for_port(port: u16) -> Arc<TrafficCounters> {
-    registry()
-        .entry(port)
+pub async fn get_counters_for_port(port: u16) -> Arc<TrafficCounters> {
+    let mut map = registry().write().await;
+    map.entry(port)
         .or_insert_with(|| Arc::new(TrafficCounters::default()))
         .clone()
 }
 
 /// Reset counters for a given port
-pub fn reset_port(port: u16) {
-    let entry = registry()
+pub async fn reset_port(port: u16) {
+    let mut map = registry().write().await;
+    let entry = map
         .entry(port)
-        .or_insert_with(|| Arc::new(TrafficCounters::default()));
+        .or_insert_with(|| Arc::new(TrafficCounters::default()))
+        .clone();
     entry.reset();
 }
 
 /// Snapshot of current counters for a port
-pub fn snapshot(port: u16) -> Option<(u64, u64)> {
-    registry().get(&port).map(|c| (c.rx(), c.tx()))
+pub async fn snapshot(port: u16) -> Option<(u64, u64)> {
+    let map = registry().read().await;
+    map.get(&port).map(|c| (c.rx(), c.tx()))
 }
 
 /// Snapshot of all counters (port, rx, tx)
 #[allow(dead_code)]
-pub fn all_snapshots() -> Vec<(u16, u64, u64)> {
-    registry()
-        .iter()
-        .map(|entry| (*entry.key(), entry.rx(), entry.tx()))
+pub async fn all_snapshots() -> Vec<(u16, u64, u64)> {
+    let map = registry().read().await;
+    map.iter()
+        .map(|(&port, counters)| (port, counters.rx(), counters.tx()))
         .collect()
 }
 
 /// Load counters from a simple text file: lines of "port\trx\ttx"
-pub fn load_from_file(path: &Path) -> io::Result<()> {
+pub async fn load_from_file(path: &Path) -> io::Result<()> {
     if !path.exists() {
         return Ok(());
     }
     let file = File::open(path)?;
     let reader = BufReader::new(file);
 
-    let map = registry();
+    let mut updates = Vec::new();
     for line in reader.lines() {
         let line = line?;
         if line.trim().is_empty() {
@@ -85,19 +102,27 @@ pub fn load_from_file(path: &Path) -> io::Result<()> {
             parts[1].parse::<u64>(),
             parts[2].parse::<u64>(),
         ) {
-            let entry = map
-                .entry(port)
-                .or_insert_with(|| Arc::new(TrafficCounters::default()));
-            entry.set(rx, tx);
+            updates.push((port, rx, tx));
         }
+    }
+
+    let mut map = registry().write().await;
+    for (port, rx, tx) in updates {
+        let entry = map
+            .entry(port)
+            .or_insert_with(|| Arc::new(TrafficCounters::default()))
+            .clone();
+        entry.set(rx, tx);
     }
     Ok(())
 }
 
 /// Save a single port's counters to a file: one line "port\trx\ttx"
-pub fn save_port_to_file(port: u16, path: &Path) -> io::Result<()> {
-    let (rx, tx) = snapshot(port).unwrap_or((0, 0));
-    if let Some(dir) = path.parent() { fs::create_dir_all(dir)?; }
+pub async fn save_port_to_file(port: u16, path: &Path) -> io::Result<()> {
+    let (rx, tx) = snapshot(port).await.unwrap_or((0, 0));
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir)?;
+    }
     let mut tmp = PathBuf::from(path);
     tmp.set_extension("tmp");
     let mut f = File::create(&tmp)?;
@@ -110,9 +135,11 @@ pub fn save_port_to_file(port: u16, path: &Path) -> io::Result<()> {
 
 /// Save all counters to a file (multi-port): lines of "port\trx\ttx"
 #[allow(dead_code)]
-pub fn save_to_file(path: &Path) -> io::Result<()> {
-    let snapshot: Vec<(u16, u64, u64)> = all_snapshots();
-    if let Some(dir) = path.parent() { fs::create_dir_all(dir)?; }
+pub async fn save_to_file(path: &Path) -> io::Result<()> {
+    let snapshot: Vec<(u16, u64, u64)> = all_snapshots().await;
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir)?;
+    }
     let mut tmp = PathBuf::from(path);
     tmp.set_extension("tmp");
     let mut f = File::create(&tmp)?;


### PR DESCRIPTION
## Summary
- replace the IP connection tracker with a Tokio `RwLock`-backed map and update callers to the async API
- refactor the buffer pool to use Tokio mutex-protected vectors and await buffer acquisition/return throughout
- wrap traffic counter registry access in an async `RwLock`, updating persistence helpers and removing the old DashMap dependency
- add Tokio's `sync` feature while dropping unused dashmap/crossbeam crates

## Testing
- cargo fmt
- cargo clippy
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dcfdbbf0c4832ab853ebf16b12f3ab