### PR TITLE
Add debug assertion for buffer pool return length

### DIFF
--- a/src/buffer_pool.rs
+++ b/src/buffer_pool.rs
@@ -58,6 +58,7 @@ impl BufferPool {
         // Zero the buffer on return to avoid leaking data between connections
         buffer.clear();
         buffer.resize(expected_size, 0);
+        debug_assert_eq!(buffer.len(), expected_size);
 
         let mut pool = if large {
             self.large_buffers.lock().await


### PR DESCRIPTION
## Summary
- ensure buffers returned to the pool retain the expected length via a debug assertion

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dd16ecac14832a94d5012a7f48d4a8
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a debug assertion to ensure buffers returned to the pool have the expected length. Catches size mismatches in development with no impact on release builds.

<!-- End of auto-generated description by cubic. -->

