### PR TITLE
Normalize domain allowlist matching

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -345,7 +345,11 @@ impl ProxyConfig {
         let listen_addr = std::net::SocketAddr::from((args.listen_ip, args.port));
 
         // Convert allowed domains to HashSet
-        let allowed_domains = args.allowed_domains.clone().map(|v| v.into_iter().collect());
+        let allowed_domains = args.allowed_domains.clone().map(|v| {
+            v.into_iter()
+                .map(|pattern| pattern.to_ascii_lowercase())
+                .collect()
+        });
 
         // Extract vendor password (-P) and SOCKS auth separately
         let vendor_password = args.auth.as_ref().and_then(|a| a.password.clone());


### PR DESCRIPTION
## Summary
- normalize allowed-domain patterns and incoming hosts so domain matching is case-insensitive
- ensure CLI configuration lowercases allow-list entries when building the runtime set
- add unit tests for mixed-case exact and wildcard hostnames

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68de0676c550832a880a051653ae1cd5
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make domain allowlist matching case-insensitive to ensure consistent enforcement across config and runtime. Normalizes patterns and incoming hosts to lowercase, with new tests for mixed-case exact and wildcard matches.

- **Bug Fixes**
  - Lowercase allowlist patterns in CLI and DomainFilter, and compare against a normalized host.
  - Case-insensitive support for exact domains, *.example.com, and .example.com.

<!-- End of auto-generated description by cubic. -->

